### PR TITLE
MoAction Feature Duty actions 1-5 (Occult Cresent Action support)

### DIFF
--- a/MOAction/Configuration/ConfigurationEntry.cs
+++ b/MOAction/Configuration/ConfigurationEntry.cs
@@ -2,6 +2,9 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using Lumina.Excel.Sheets;
+using System.Linq;
 
 namespace MOAction.Configuration;
 
@@ -9,31 +12,41 @@ namespace MOAction.Configuration;
 public class ConfigurationEntry
 {
     public uint BaseId;
+    public ActionType ActionType;
 
-    public List<(string, uint)> Stack;
+    public List<(string, uint, ActionType)> Stack;
 
     public VirtualKey Modifier;
     public uint JobIdx;
 
-    public ConfigurationEntry(uint baseId, List<(string, uint)> stack, VirtualKey modifier, uint job)
+
+    public ConfigurationEntry(uint baseId, List<(string, uint, ActionType)> stack, VirtualKey modifier, uint job, ActionType actionType)
     {
         BaseId = baseId;
         Stack = stack;
         Modifier = modifier;
         JobIdx = job;
+        ActionType = actionType;
     }
 
     [JsonConstructor]
-    [Obsolete("This constructor is a one-time migration from the old job string to jobIdx uint. Added 16/12/2024")]
-    public ConfigurationEntry(uint baseId, List<(string, uint)> stack, VirtualKey modifier, uint jobIdx, string job = null)
+    [Obsolete("This constructor is a one-time migration from the old job string to jobIdx uint and/or from the old stack to the new stack Added 28/05/2025")]
+    public ConfigurationEntry(uint baseId, List<(string, uint, ActionType)> stack, VirtualKey modifier, uint jobIdx, List<(string, uint)> oldstack = null, string job = null, ActionType? actionType = null)
     {
         BaseId = baseId;
-        Stack = stack;
         Modifier = modifier;
-
         if (job == null)
             JobIdx = jobIdx;
         else
             JobIdx = uint.TryParse(job, out var num) ? num : 0;
+        if (oldstack == null)
+            Stack = stack;
+        else
+            Stack = [.. stack.Select(item => (item.Item1, item.Item2, ActionType.Action))];
+        if (actionType == null)
+            ActionType = ActionType.Action;
+        else
+            ActionType = actionType!.Value;
     }
+
 }

--- a/MOAction/Configuration/MOActionConfiguration.cs
+++ b/MOAction/Configuration/MOActionConfiguration.cs
@@ -21,6 +21,8 @@ public class MOActionConfiguration : IPluginConfiguration
     public Vector4 CrosshairValidColor = ImGuiColors.DalamudOrange;
     public Vector4 CrosshairCastColor = ImGuiColors.ParsedGreen;
 
+    public bool IncludeDutyActions = false;
+
     public bool RangeCheck;
 
     public MOActionConfiguration()

--- a/MOAction/Configuration/MOActionWrapper.cs
+++ b/MOAction/Configuration/MOActionWrapper.cs
@@ -1,0 +1,74 @@
+namespace MOAction.Configuration;
+using System;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using Lumina.Excel;
+using Lumina.Excel.Sheets;
+
+public class MOActionWrapper
+{
+    public Lumina.Excel.Sheets.Action? Action { get; private set; } = null;
+    public Lumina.Excel.Sheets.GeneralAction? GeneralAction { get; private set; } = null;
+
+    public ActionType actionType { get; private set; }
+
+    public MOActionWrapper(Lumina.Excel.Sheets.Action action)
+    {
+        this.Action = action;
+        this.actionType = ActionType.Action;
+    }
+
+    public MOActionWrapper(Lumina.Excel.Sheets.GeneralAction generalAction)
+    {
+        this.GeneralAction = generalAction;
+        this.actionType = ActionType.GeneralAction;
+    }
+
+    public MOActionWrapper()
+    {
+        this.actionType = ActionType.None;
+    }
+
+    public uint RowId()
+    {
+        if (Action != null)
+        {
+            return Action!.Value.RowId;
+        }
+        if (GeneralAction != null)
+        {
+            return GeneralAction!.Value.RowId;
+        }
+        return default;
+    }
+
+    public bool TargetArea()
+    {
+        if (Action != null)
+        {
+            return Action.Value.TargetArea;
+        }
+        return false;
+    }
+
+    public string Name()
+    {
+        if (Action != null)
+        {
+            return Action!.Value.Name.ExtractText();
+        }
+        if (GeneralAction != null)
+        {
+            return GeneralAction!.Value.Name.ExtractText();
+        }
+        return string.Empty;
+    }
+
+    public string ClassJobCategory()
+    {
+        if (Action != null)
+        {
+            return Action!.Value.ClassJobCategory.Value.Name.ExtractText();
+        }
+        return string.Empty;
+    }
+}

--- a/MOAction/Configuration/MOActionWrapper.cs
+++ b/MOAction/Configuration/MOActionWrapper.cs
@@ -1,74 +1,64 @@
 namespace MOAction.Configuration;
-using System;
 using FFXIVClientStructs.FFXIV.Client.Game;
-using Lumina.Excel;
 using Lumina.Excel.Sheets;
 
+/// <summary>
+/// Helper wrapper class to be able to act on an Action or GeneralAction in an identical fashion.
+/// </summary>
 public class MOActionWrapper
 {
-    public Lumina.Excel.Sheets.Action? Action { get; private set; } = null;
-    public Lumina.Excel.Sheets.GeneralAction? GeneralAction { get; private set; } = null;
+    private Action? Action { get; }
+    private GeneralAction? GeneralAction { get; }
 
     public ActionType actionType { get; private set; }
 
-    public MOActionWrapper(Lumina.Excel.Sheets.Action action)
+    public MOActionWrapper(Action action)
     {
-        this.Action = action;
-        this.actionType = ActionType.Action;
+        Action = action;
+        actionType = ActionType.Action;
     }
 
-    public MOActionWrapper(Lumina.Excel.Sheets.GeneralAction generalAction)
+    public MOActionWrapper(GeneralAction generalAction)
     {
-        this.GeneralAction = generalAction;
-        this.actionType = ActionType.GeneralAction;
+        GeneralAction = generalAction;
+        actionType = ActionType.GeneralAction;
     }
 
     public MOActionWrapper()
     {
-        this.actionType = ActionType.None;
+        actionType = ActionType.None;
     }
 
     public uint RowId()
     {
         if (Action != null)
-        {
             return Action!.Value.RowId;
-        }
         if (GeneralAction != null)
-        {
             return GeneralAction!.Value.RowId;
-        }
-        return default;
+        return 0;
     }
 
     public bool TargetArea()
     {
         if (Action != null)
-        {
             return Action.Value.TargetArea;
-        }
+
         return false;
     }
 
     public string Name()
     {
         if (Action != null)
-        {
             return Action!.Value.Name.ExtractText();
-        }
         if (GeneralAction != null)
-        {
             return GeneralAction!.Value.Name.ExtractText();
-        }
         return string.Empty;
     }
 
     public string ClassJobCategory()
     {
         if (Action != null)
-        {
             return Action!.Value.ClassJobCategory.Value.Name.ExtractText();
-        }
         return string.Empty;
     }
 }

--- a/MOAction/Configuration/MoActionStack.cs
+++ b/MOAction/Configuration/MoActionStack.cs
@@ -8,7 +8,7 @@ namespace MOAction.Configuration;
 public class MoActionStack : IEquatable<MoActionStack>, IComparable<MoActionStack>
 {
     public static readonly VirtualKey[] AllKeys = [VirtualKey.NO_KEY, VirtualKey.SHIFT, VirtualKey.MENU, VirtualKey.CONTROL];
-    public Lumina.Excel.Sheets.Action BaseAction { get; set; }
+    public MOActionWrapper BaseAction { get; set; }
     public List<StackEntry> Entries { get; set; }
     public uint Job { get; set; }
 
@@ -16,8 +16,30 @@ public class MoActionStack : IEquatable<MoActionStack>, IComparable<MoActionStac
 
     public MoActionStack(Lumina.Excel.Sheets.Action baseAction, List<StackEntry> list)
     {
+        BaseAction = new(baseAction);
+        Entries = list ?? [];
+        Job = uint.MaxValue;
+        Modifier = 0;
+    }
+
+    public MoActionStack(Lumina.Excel.Sheets.GeneralAction baseAction, List<StackEntry> list)
+    {
+        BaseAction = new(baseAction);
+        Entries = list ?? [];
+        Job = uint.MaxValue;
+        Modifier = 0;
+    }
+     public MoActionStack(MOActionWrapper baseAction, List<StackEntry> list)
+    {
         BaseAction = baseAction;
         Entries = list ?? [];
+        Job = uint.MaxValue;
+        Modifier = 0;
+    }
+     public MoActionStack()
+    {
+        BaseAction = new();
+        Entries = [];
         Job = uint.MaxValue;
         Modifier = 0;
     }
@@ -31,14 +53,14 @@ public class MoActionStack : IEquatable<MoActionStack>, IComparable<MoActionStac
         {
             var myEntry = Entries[i];
             var theirEntry = c.Stack[i];
-            if (myEntry.Target.TargetName != theirEntry.Item1 && myEntry.Action.RowId != theirEntry.Item2)
+            if (myEntry.Target.TargetName != theirEntry.Item1 && myEntry.Action.RowId() != theirEntry.Item2)
                 return false;
         }
 
         if (Modifier != c.Modifier)
             return false;
 
-        if (BaseAction.RowId != c.BaseId)
+        if (BaseAction.RowId() != c.BaseId)
             return false;
 
         return true;
@@ -50,13 +72,13 @@ public class MoActionStack : IEquatable<MoActionStack>, IComparable<MoActionStac
         if (other == null)
             return 1;
 
-        return string.Compare(BaseAction.Name.ExtractText(), other.BaseAction.Name.ExtractText(), StringComparison.Ordinal);
+        return string.Compare(BaseAction.Name(), other.BaseAction.Name(), StringComparison.Ordinal);
     }
 
     //TODO make the overwritten equals and hashcodes a bit more smart, to not ignore the deeper stackentry list
     public override int GetHashCode()
     {
-        return (int)(BaseAction.RowId + Job.GetHashCode() + (int)Modifier);
+        return (int)(BaseAction.RowId() + Job.GetHashCode() + (int)Modifier);
     }
 
     //TODO make the overwritten equals and hashcodes a bit more smart, to not ignore the deeper stackentry list
@@ -88,5 +110,5 @@ public class MoActionStack : IEquatable<MoActionStack>, IComparable<MoActionStac
         return Job == uint.MaxValue ? "Unset Job" : Job.ToString();
     }
 
-    public override string ToString() => $"{BaseAction.Name.ExtractText()} - {string.Join(", ",Entries.Select(entry => $"[{entry}]"))}";
+    public override string ToString() => $"{BaseAction.Name()} - {string.Join(", ",Entries.Select(entry => $"[{entry}]"))}";
 }

--- a/MOAction/Configuration/StackEntry.cs
+++ b/MOAction/Configuration/StackEntry.cs
@@ -4,14 +4,25 @@ namespace MOAction.Configuration;
 
 public class StackEntry
 {
-    public Lumina.Excel.Sheets.Action Action;
+    public MOActionWrapper Action;
     public TargetType Target { get; set; }
 
     public StackEntry(Lumina.Excel.Sheets.Action action, TargetType targ)
+    {
+        Action = new(action);
+        Target = targ;
+    }
+
+    public StackEntry(Lumina.Excel.Sheets.GeneralAction action, TargetType targ)
+    {
+        Action = new(action);
+        Target = targ;
+    }
+    public StackEntry(MOActionWrapper action, TargetType targ)
     {
         Action = action;
         Target = targ;
     }
 
-    public override string ToString() => $"{Action.Name.ExtractText()}@{Target}";
+    public override string ToString() => $"{Action.Name}@{Target}";
 }

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -52,10 +52,13 @@ public class MOAction
         }
     }
 
+    /// <summary>
+    /// Main hooked function for the Mouse over action plugin, it intercepts the requested action
+    /// </summary>
     private unsafe bool HandleRequestAction(ActionManager* thisPtr, ActionType actionType, uint actionId, ulong targetId, uint extraParam, ActionManager.UseActionMode mode, uint comboRouteId, bool* outOptAreaTargeted)
     {
         // Only care about "real" actions. Not doing anything dodgy
-        if (!(actionType == ActionType.Action))
+        if (actionType != ActionType.Action)
             return RequestActionHook.Original(thisPtr, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
         Plugin.PluginLog.Verbose($"Receiving handling request for Action: {actionId}");
 
@@ -84,9 +87,14 @@ public class MOAction
         return ret;
     }
 
-    private unsafe (Lumina.Excel.Sheets.Action action, IGameObject target) GetActionTarget(uint actionID, ActionType actionType)
+    /// <summary>
+    ///  gets the target and the action to use.
+    /// </summary>
+    /// <param name="actionId">the action id being handled</param>
+    /// <param name="actionType">action type is only used in the off-cooldown check, should always be "Action"</param>
+    private unsafe (Lumina.Excel.Sheets.Action action, IGameObject target) GetActionTarget(uint actionId, ActionType actionType)
     {
-        if (!Sheets.ActionSheet.TryGetRow(actionID, out var action))
+        if (!Sheets.ActionSheet.TryGetRow(actionId, out var action))
         {
             Plugin.PluginLog.Verbose("ILLEGAL STATE: Lumina Excel did not succesfully retrieve row.\nFailsafe triggering early return");
             return (default, null);
@@ -110,28 +118,41 @@ public class MOAction
             return (default, null);
         }
         var actionManager = ActionManager.Instance();
-        var adjusted = actionManager->GetAdjustedActionId(actionID);
-        IEnumerable<MoActionStack> applicableActions;
-        if (action.RowId == DutyActionManager.GetDutyActionId(0))
+        var adjusted = actionManager->GetAdjustedActionId(actionId);
+
+        //Loop through Duty actions 0 -> slots of duty actions
+        //NumValidSlots is at most 4, this is in Occult Cresent
+        var applicableActions = Enumerable.Empty<MoActionStack>();
+        var isDutyAction = false;
+        var dutyActionManager = DutyActionManager.GetInstanceIfReady();
+        if (dutyActionManager != null)
         {
-            applicableActions = Stacks.Where(entry => entry.BaseAction.actionType == ActionType.GeneralAction && entry.BaseAction.RowId() == 26);
+            for (ushort dutyActionSlot = 0; dutyActionSlot < dutyActionManager->NumValidSlots; dutyActionSlot++)
+            {
+                if (action.RowId != DutyActionManager.GetDutyActionId(dutyActionSlot))
+                    continue;
+
+                Plugin.PluginLog.Verbose("We're dealing with a duty action");
+                isDutyAction = true;
+                //Fetch the stacks we linked to phantom actions 1-5 to match between duty actions 0-4
+                applicableActions = Stacks.Where(entry =>
+                    entry.BaseAction.actionType == ActionType.GeneralAction &&
+                    entry.BaseAction.RowId() == 31 + dutyActionSlot);
+                break;
+            }
         }
-        else if (action.RowId == DutyActionManager.GetDutyActionId(1))
-        {
-            applicableActions = Stacks.Where(entry => entry.BaseAction.actionType == ActionType.GeneralAction && entry.BaseAction.RowId() == 27);
-        }
-        //TODO add custom logic to fetch what is currently inside the phantom action buttons 1-5 and compare that to the current actionid, if they match, fetch the stacks for the phantom actions 1-5
-        else
+
+        if (!isDutyAction)
         {
             applicableActions = Stacks.Where(entry =>
                 entry.BaseAction.actionType == ActionType.Action &&
                 (
-                entry.BaseAction.RowId() == action.RowId ||
-                entry.BaseAction.RowId() == adjusted ||
-                actionManager->GetAdjustedActionId(entry.BaseAction.RowId()) == adjusted
+                    entry.BaseAction.RowId() == action.RowId ||
+                    entry.BaseAction.RowId() == adjusted ||
+                    actionManager->GetAdjustedActionId(entry.BaseAction.RowId()) == adjusted
                 )
                 && VerifyJobEqualsOrEqualsParentJob(entry.Job, Plugin.ClientState.LocalPlayer.ClassJob.RowId)
-                );
+            );
         }
 
         MoActionStack stackToUse = null;
@@ -157,7 +178,7 @@ public class MOAction
         foreach (var entry in stackToUse.Entries)
         {
             Plugin.PluginLog.Verbose($"unadjusted entry action, {entry.Action.RowId()}, {entry.Action.Name()}");
-            if ( CanUseAction(entry, actionType, out var target, out var usedAction))
+            if (CanUseAction(entry, actionType, out var target, out var usedAction))
             {
                 return (usedAction, target);
             }
@@ -167,57 +188,39 @@ public class MOAction
         return (default, null);
     }
 
-    private unsafe bool CanUseAction(StackEntry stackentry, ActionType actionType, out IGameObject usedTarget, out Lumina.Excel.Sheets.Action action)
+    /// <summary>
+    /// Figures out if you are able to cast the action inside stackentry at the target inside the stack entry.
+    /// </summary>
+    /// <param name="stackentry">stack entry to be checked</param>
+    /// <param name="actionType">used for the cooldown check, should always be "Action"</param>
+    /// <param name="target">out parameter, the target to return to the hook to fire the spell at</param>
+    /// <param name="action">out parameter, the spell to return to the hook to fire at the target</param>
+    private unsafe bool CanUseAction(StackEntry stackentry, ActionType actionType, out IGameObject target, out Lumina.Excel.Sheets.Action action)
     {
-
-        usedTarget = null;
+        target = stackentry.Target.GetTarget();
         var id = stackentry.Action.RowId();
-        if (stackentry.Target == null || id == 0 || Plugin.ClientState.LocalPlayer == null)
+        //Early sanity checks
+        if (stackentry.Target == null || id == 0 || Plugin.ClientState.LocalPlayer == null || stackentry.Action.actionType is not (ActionType.GeneralAction or ActionType.Action))
         {
             action = default;
             return false;
         }
         var actionManager = ActionManager.Instance();
+        //assign the out action to the action to be checked if can be used
         if (stackentry.Action.actionType == ActionType.Action)
         {
-            if (id == 0)
-            {
-                action = default;
-                return false;
-            }
-
             if (!Sheets.ActionSheet.TryGetRow(actionManager->GetAdjustedActionId(id), out action))
-            {
                 return false; // just in case
-            }
-
         }
         else
         {
-            if (!(stackentry.Action.actionType == ActionType.GeneralAction))
-            {
-                action = default;
-                return false;
-            }
-
-            if (!Utils.getActionFromGeneralDutyAction(stackentry.Action.GeneralAction!.Value, out action))
+            if (!Utils.GetDutyActionRow(id, out action))
                 return false;
         }
 
-        var target = stackentry.Target.GetTarget();
+        //if there's no target, return false unless it is a ground target action at mousepoint.
         if (target == null)
-        {
-            if (stackentry.Target.ObjectNeeded)
-            {
-                usedTarget = Plugin.ClientState.LocalPlayer;
-                return false;
-            }
-            else
-            {
-                return true;
-            }
-        }
-        usedTarget = target;
+            return !stackentry.Target.ObjectNeeded;
 
         // Check if ability is on CD or not (charges are fun!)
         var abilityOnCoolDownResponse = actionManager->IsActionOffCooldown(actionType, action.RowId);
@@ -226,7 +229,7 @@ public class MOAction
             return false;
 
         var player = Plugin.ClientState.LocalPlayer;
-        var targetPtr = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)usedTarget.Address;
+        var targetPtr = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)target.Address;
         if (Plugin.Configuration.RangeCheck)
         {
             var playerPtr = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)player.Address;
@@ -254,11 +257,11 @@ public class MOAction
         if (selfOnlyTargetAction)
         {
             Plugin.PluginLog.Verbose("Can only use this action on player, setting player as target");
-            usedTarget = Plugin.ClientState.LocalPlayer;
+            target = Plugin.ClientState.LocalPlayer;
         }
 
-        var gameCanUseActionResponse = ActionManager.CanUseActionOnTarget(action.RowId, (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)usedTarget.Address);
-        Plugin.PluginLog.Verbose($"Can I use action: {action.RowId} with name {action.Name.ExtractText()} on target {usedTarget.DataId} with name {usedTarget.Name} : {gameCanUseActionResponse}");
+        var gameCanUseActionResponse = ActionManager.CanUseActionOnTarget(action.RowId, (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)target.Address);
+        Plugin.PluginLog.Verbose($"Can I use action: {action.RowId} with name {action.Name.ExtractText()} on target {target.DataId} with name {target.Name} : {gameCanUseActionResponse}");
         return gameCanUseActionResponse;
     }
 

--- a/MOAction/MOAction.cs
+++ b/MOAction/MOAction.cs
@@ -55,7 +55,7 @@ public class MOAction
     private unsafe bool HandleRequestAction(ActionManager* thisPtr, ActionType actionType, uint actionId, ulong targetId, uint extraParam, ActionManager.UseActionMode mode, uint comboRouteId, bool* outOptAreaTargeted)
     {
         // Only care about "real" actions. Not doing anything dodgy
-        if (actionType != ActionType.Action)
+        if (!(actionType == ActionType.Action))
             return RequestActionHook.Original(thisPtr, actionType, actionId, targetId, extraParam, mode, comboRouteId, outOptAreaTargeted);
         Plugin.PluginLog.Verbose($"Receiving handling request for Action: {actionId}");
 
@@ -109,16 +109,35 @@ public class MOAction
             Plugin.PluginLog.Verbose("ILLEGAL STATE: Dalamud thinks you're an ADV\nFailsafe triggering early return");
             return (default, null);
         }
-
         var actionManager = ActionManager.Instance();
         var adjusted = actionManager->GetAdjustedActionId(actionID);
+        Plugin.PluginLog.Verbose($"{adjusted}");
 
-        var applicableActions = Stacks.Where(entry =>
-            (entry.BaseAction.RowId == action.RowId ||
-            entry.BaseAction.RowId == adjusted ||
-            actionManager->GetAdjustedActionId(entry.BaseAction.RowId) == adjusted)
-            && VerifyJobEqualsOrEqualsParentJob(entry.Job, Plugin.ClientState.LocalPlayer.ClassJob.RowId)
-            );
+
+        var firstdutyactionid = DutyActionManager.GetDutyActionId(0);
+        var seconddutyactionid = DutyActionManager.GetDutyActionId(1);
+        IEnumerable<MoActionStack> applicableActions;
+        if (action.RowId == firstdutyactionid)
+        {
+            applicableActions = Stacks.Where(entry => entry.BaseAction.actionType == ActionType.GeneralAction && entry.BaseAction.RowId() == 26);
+        }
+        else if (action.RowId == seconddutyactionid)
+        {
+            applicableActions = Stacks.Where(entry => entry.BaseAction.actionType == ActionType.GeneralAction && entry.BaseAction.RowId() == 27);
+        }
+        //TODO add custom logic to fetch what is currently inside the phantom action buttons 1-5 and compare that to the current actionid, if they match, fetch the stacks for the phantom actions 1-5
+        else
+        {
+            applicableActions = Stacks.Where(entry =>
+                entry.BaseAction.actionType == ActionType.Action &&
+                (
+                entry.BaseAction.RowId() == action.RowId ||
+                entry.BaseAction.RowId() == adjusted ||
+                actionManager->GetAdjustedActionId(entry.BaseAction.RowId()) == adjusted
+                )
+                && VerifyJobEqualsOrEqualsParentJob(entry.Job, Plugin.ClientState.LocalPlayer.ClassJob.RowId)
+                );
+        }
 
         MoActionStack stackToUse = null;
         foreach (var entry in applicableActions)
@@ -142,10 +161,10 @@ public class MOAction
 
         foreach (var entry in stackToUse.Entries)
         {
-            Plugin.PluginLog.Verbose($"unadjusted entry action, {entry.Action.RowId}, {entry.Action.Name.ExtractText()}");
+            Plugin.PluginLog.Verbose($"unadjusted entry action, {entry.Action.RowId()}, {entry.Action.Name()}");
             var (response, target) = CanUseAction(entry, actionType);
             if (response)
-                return (entry.Action, target);
+                return (entry.Action.Action!.Value, target);
         }
 
         Plugin.PluginLog.Verbose("Chosen MoAction Entry stack did not have any usable actions.");
@@ -154,11 +173,36 @@ public class MOAction
 
     private unsafe (bool, IGameObject Target) CanUseAction(StackEntry targ, ActionType actionType)
     {
-        if (targ.Target == null || targ.Action.RowId == 0 || Plugin.ClientState.LocalPlayer == null)
+        if (targ.Target == null || targ.Action.RowId() == 0 || Plugin.ClientState.LocalPlayer == null)
             return (false, null);
 
         var actionManager = ActionManager.Instance();
-        if (!Sheets.ActionSheet.TryGetRow(actionManager->GetAdjustedActionId(targ.Action.RowId), out var action))
+
+        uint id = 0;
+        if (targ.Action.actionType == ActionType.Action)
+        {
+            id = targ.Action.RowId();
+        }
+        else
+        {
+            //Handling duty actions 1 and 2
+            if (targ.Action.actionType == ActionType.GeneralAction)
+            {
+                if (targ.Action.RowId() == 26)
+                {
+                    id = DutyActionManager.GetDutyActionId(0);
+                }
+                else if (targ.Action.RowId() == 27)
+                {
+                    id = DutyActionManager.GetDutyActionId(1);
+                }
+                //TODO find a way to custom handle actions 31-35 so that the action currently in the Phantom action 1-5 button is fetched on "action" 31-35
+            }
+        }
+        if (id == 0)
+            return (false, null);
+
+        if (!Sheets.ActionSheet.TryGetRow(actionManager->GetAdjustedActionId(id), out var action))
             return (false, null); // just in case
 
         var target = targ.Target.GetTarget();

--- a/MOAction/Plugin.cs
+++ b/MOAction/Plugin.cs
@@ -49,8 +49,9 @@ public class Plugin : IDalamudPlugin
     public readonly List<Lumina.Excel.Sheets.ClassJob> JobAbbreviations;
     public Dictionary<uint, List<MOActionWrapper>> JobActions = [];
 
-    //26/27 are duty actions, 31-35 are phantom skills, phantom skills not yet implemented
-    public static readonly uint[] dutyActionRowIds = [26, 27, 31, 32, 33, 34, 35];
+    //31-35 are phantom actions 1-5, they're used as flags to be able to build stacks on duty action 1-5
+    //A more elegant solution is something I did not immediately find.
+    public static readonly uint[] UsedDutyActionRowIds = [31, 32, 33, 34, 35];
 
     public Plugin()
     {
@@ -267,7 +268,7 @@ public class Plugin : IDalamudPlugin
         ApplicableActions = [.. Sheets.ActionSheet.Where(row => row is { IsPlayerAction: true, IsPvP: false, ClassJobLevel: > 0 }).Where(a => a.RowId != 212).Select(y => { return new MOActionWrapper(y); })];
         if (Configuration.IncludeDutyActions)
         {
-            foreach (uint dutyActionRowId in dutyActionRowIds)
+            foreach (uint dutyActionRowId in UsedDutyActionRowIds)
             {
                 ApplicableActions.Add(new MOActionWrapper(Sheets.GeneralActions.GetRow(dutyActionRowId)));
             }
@@ -283,7 +284,7 @@ public class Plugin : IDalamudPlugin
             }).ToList();
             if (Configuration.IncludeDutyActions)
             {
-                foreach (uint dutyActionRowId in dutyActionRowIds)
+                foreach (uint dutyActionRowId in UsedDutyActionRowIds)
                 {
                     availableActions.Add(new MOActionWrapper(Sheets.GeneralActions.GetRow(dutyActionRowId)));
                 }

--- a/MOAction/Sheets.cs
+++ b/MOAction/Sheets.cs
@@ -7,10 +7,12 @@ public static class Sheets
 {
     public static readonly ExcelSheet<Action> ActionSheet;
     public static readonly ExcelSheet<ClassJob> ClassJobSheet;
+    public static readonly ExcelSheet<GeneralAction> GeneralActions;
 
     static Sheets()
     {
         ActionSheet = Plugin.DataManager.GetExcelSheet<Action>();
         ClassJobSheet = Plugin.DataManager.GetExcelSheet<ClassJob>();
+        GeneralActions = Plugin.DataManager.GetExcelSheet<GeneralAction>();
     }
 }

--- a/MOAction/Utils.cs
+++ b/MOAction/Utils.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Lumina.Excel.Sheets;
+using MOAction.Configuration;
 
 namespace MOAction;
 
@@ -25,15 +26,15 @@ public static class Utils
     }
 }
 
-public class ActionComparer : IEqualityComparer<Action>
+public class ActionWrapperComparer : IEqualityComparer<MOActionWrapper>
 {
-    bool IEqualityComparer<Action>.Equals(Action x, Action y)
+    bool IEqualityComparer<MOActionWrapper>.Equals(MOActionWrapper x, MOActionWrapper y)
     {
-        return x.RowId == y.RowId;
+        return x.RowId() == y.RowId() && x.actionType == y.actionType;
     }
 
-    int IEqualityComparer<Action>.GetHashCode(Action obj)
+    int IEqualityComparer<MOActionWrapper>.GetHashCode(MOActionWrapper obj)
     {
-        return obj.RowId.GetHashCode();
+        return obj.RowId().GetHashCode();
     }
 }

--- a/MOAction/Utils.cs
+++ b/MOAction/Utils.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Lumina.Excel.Sheets;
 using MOAction.Configuration;
+using FFXIVClientStructs.FFXIV.Client.Game;
 
 namespace MOAction;
 
@@ -24,6 +25,29 @@ public static class Utils
     {
         (list[i], list[j]) = (list[j], list[i]);
     }
+
+    public static unsafe bool getActionFromGeneralDutyAction(GeneralAction generalAction, out Action action)
+    {
+        var actionManager = ActionManager.Instance();
+        uint id = 0;
+        if (generalAction.RowId == 26)
+        {
+            id = DutyActionManager.GetDutyActionId(0);
+        }
+        else if (generalAction.RowId == 27)
+        {
+            id = DutyActionManager.GetDutyActionId(1);
+        }
+
+        if (id == 0)
+        {
+            action = default;
+            return false;
+        }
+
+        return Sheets.ActionSheet.TryGetRow(actionManager->GetAdjustedActionId(id), out action);
+
+    }
 }
 
 public class ActionWrapperComparer : IEqualityComparer<MOActionWrapper>
@@ -38,3 +62,4 @@ public class ActionWrapperComparer : IEqualityComparer<MOActionWrapper>
         return obj.RowId().GetHashCode();
     }
 }
+

--- a/MOAction/Utils.cs
+++ b/MOAction/Utils.cs
@@ -26,27 +26,32 @@ public static class Utils
         (list[i], list[j]) = (list[j], list[i]);
     }
 
-    public static unsafe bool getActionFromGeneralDutyAction(GeneralAction generalAction, out Action action)
+    /// <summary>
+    /// Grabs whatever actionId is currently inside the duty action slot with index 0-4
+    /// </summary>
+    /// <param name="rowId">the rowId of the general actions used as placeholder, ranging from 31 to 35</param>
+    /// <param name="action">out parameter, the duty action</param>
+    /// <returns>success or not</returns>
+    public static unsafe bool GetDutyActionRow(uint rowId, out Action action)
     {
         var actionManager = ActionManager.Instance();
-        uint id = 0;
-        if (generalAction.RowId == 26)
+        if (rowId is < 30 or > 36)
         {
-            id = DutyActionManager.GetDutyActionId(0);
+                action = default;
+                return false;
         }
-        else if (generalAction.RowId == 27)
+        //Phantom actions are 31-35, so to get slot 0-4 from 31-35
+        var dutyActionSlot = rowId - 31;
+        var id = DutyActionManager.GetDutyActionId((ushort)dutyActionSlot);
+
+        if (id > 0)
         {
-            id = DutyActionManager.GetDutyActionId(1);
+            Plugin.PluginLog.Verbose($"Duty Action with rowID {id} selected from duty action slot {dutyActionSlot}");
+            return Sheets.ActionSheet.TryGetRow(actionManager->GetAdjustedActionId(id), out action);
         }
 
-        if (id == 0)
-        {
-            action = default;
-            return false;
-        }
-
-        return Sheets.ActionSheet.TryGetRow(actionManager->GetAdjustedActionId(id), out action);
-
+        action = default;
+        return false;
     }
 }
 

--- a/MOAction/Windows/Config/ConfigWindow.Settings.cs
+++ b/MOAction/Windows/Config/ConfigWindow.Settings.cs
@@ -1,15 +1,12 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Text;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility.Raii;
 using ImGuiNET;
 using MOAction.Configuration;
-using Newtonsoft.Json;
 
 namespace MOAction.Windows.Config;
 
@@ -28,19 +25,20 @@ public partial class ConfigWindow
             Dalamud.Utility.Util.OpenLink("https://youtu.be/pm4eCxD90gs");
 
         ImGui.Checkbox("Stack entry fails if target is out of range.", ref Plugin.Configuration.RangeCheck);
+        ImGui.Checkbox("Enable Duty Actions as stacks", ref Plugin.Configuration.IncludeDutyActions);
         ImGui.TextUnformatted("MoAction Crosshair location (you'll have to draw it yourself with an overlay)");
         ImGui.SetNextItemWidth(100);
-        ImGui.InputInt("X-coordinate",ref Plugin.Configuration.CrosshairWidth);
+        ImGui.InputInt("X-coordinate", ref Plugin.Configuration.CrosshairWidth);
         ImGui.SetNextItemWidth(100);
-        ImGui.InputInt("Y-coordinate",ref Plugin.Configuration.CrosshairHeight);
+        ImGui.InputInt("Y-coordinate", ref Plugin.Configuration.CrosshairHeight);
         ImGui.Checkbox("Enable Crosshair Draw", ref Plugin.Configuration.DrawCrosshair);
         if (Plugin.Configuration.DrawCrosshair)
         {
             using var indent = ImRaii.PushIndent(10.0f);
             ImGui.SetNextItemWidth(100);
-            ImGui.InputFloat("Size",ref Plugin.Configuration.CrosshairSize);
+            ImGui.InputFloat("Size", ref Plugin.Configuration.CrosshairSize);
             ImGui.SetNextItemWidth(100);
-            ImGui.InputFloat("Thickness",ref Plugin.Configuration.CrosshairThickness);
+            ImGui.InputFloat("Thickness", ref Plugin.Configuration.CrosshairThickness);
 
             var spacing = ImGui.CalcTextSize("Target Acquired").X + (ImGui.GetFrameHeightWithSpacing() * 2);
             Helper.ColorPickerWithReset("No Target", ref Plugin.Configuration.CrosshairInvalidColor, ImGuiColors.DalamudRed, spacing);
@@ -102,6 +100,7 @@ public partial class ConfigWindow
         if (ImGui.Button("Save"))
         {
             Plugin.SaveStacks();
+            Plugin.InitUsableActions();
         }
 
         ImGui.SameLine();
@@ -109,6 +108,7 @@ public partial class ConfigWindow
         {
             IsOpen = false;
             Plugin.SaveStacks();
+            Plugin.InitUsableActions();
         }
 
         ImGui.SameLine();
@@ -116,7 +116,7 @@ public partial class ConfigWindow
         {
             if (Plugin.ClientState.LocalPlayer != null)
             {
-                MoActionStack stack = new(default, null);
+                MoActionStack stack = new();
                 var job = Plugin.ClientState.LocalPlayer.ClassJob.RowId;
 
                 stack.Job = job;
@@ -125,7 +125,7 @@ public partial class ConfigWindow
             }
             else
             {
-                Plugin.NewStacks.Add(new MoActionStack(default, []));
+                Plugin.NewStacks.Add(new MoActionStack());
             }
         }
     }
@@ -138,7 +138,7 @@ public partial class ConfigWindow
             var targetComboLength = ImGui.CalcTextSize("Target of Target   ").X + ImGui.GetFrameHeightWithSpacing();
 
             var entry = list.ElementAt(i);
-            if (!ImGui.CollapsingHeader(entry.BaseAction.RowId == 0 ? "Unset Action###" : $"{entry.BaseAction.Name.ExtractText()}###"))
+            if (!ImGui.CollapsingHeader(entry.BaseAction.RowId() == 0 ? "Unset Action###" : $"{entry.BaseAction.Name()}###"))
                 continue;
 
             // Require user to select a job, filtering actions down.
@@ -155,9 +155,9 @@ public partial class ConfigWindow
                         var job = c.RowId;
                         if (entry.Job != job)
                         {
-                            entry.BaseAction = default;
+                            entry.BaseAction = new();
                             foreach (var stackentry in entry.Entries)
-                                stackentry.Action = default;
+                                stackentry.Action = new();
                         }
 
                         entry.Job = job;
@@ -180,28 +180,33 @@ public partial class ConfigWindow
             if (entry.Job is > 0 and < uint.MaxValue)
             {
                 using var indent = ImRaii.PushIndent();
-                ExcelSheetSelector<Lumina.Excel.Sheets.Action>.ExcelSheetComboOptions actionOptions = new()
-                {
-                    FormatRow = a => a.RowId switch { _ => a.Name.ExtractText() },
-                    FilteredSheet = Plugin.JobActions[entry.Job],
-                };
+                var actionOptions = Plugin.JobActions[entry.Job];
 
                 // Select base action.
                 ImGui.SetNextItemWidth(200);
-                var baseSelected = entry.BaseAction.RowId;
-                if (ExcelSheetSelector<Lumina.Excel.Sheets.Action>.ExcelSheetCombo("Base Action", ref baseSelected, entry.Job, actionOptions))
+                var baseSelected = entry.BaseAction.RowId();
+                using (var combo = ImRaii.Combo("Base Action", entry.BaseAction.Name()))
                 {
-                    var ability = Sheets.ActionSheet.GetRow(baseSelected);
+                    if (combo.Success)
+                    {
+                        foreach (var action in actionOptions)
+                        {
+                            if (!ImGui.Selectable(action.Name()))
+                                continue;
+                            entry.BaseAction = action;
+                            if (entry.Entries.Count == 0)
+                            {
+                                entry.Entries.Add(new StackEntry(action, Plugin.TargetTypes[0]));
+                            }
+                            else
+                            {
+                                entry.Entries[0].Action = action;
+                            }
+                        }
 
-                    // By default, add UI mouseover as the first TargetType
-                    entry.BaseAction = ability;
-                    if (entry.Entries.Count == 0)
-                        entry.Entries.Add(new StackEntry(ability, Plugin.TargetTypes[0]));
-                    else
-                        entry.Entries[0].Action = ability;
+                    }
                 }
-
-                if (entry.BaseAction.RowId == 0)
+                if (entry.BaseAction.RowId() == 0)
                     continue;
 
                 using (ImRaii.PushIndent())
@@ -220,7 +225,7 @@ public partial class ConfigWindow
                         {
                             if (innerCombo.Success)
                             {
-                                foreach (var target in stackEntry.Action.TargetArea ? Plugin.TargetTypes.Append(Plugin.GroundTargetTypes) : Plugin.TargetTypes)
+                                foreach (var target in stackEntry.Action.TargetArea() ? Plugin.TargetTypes.Append(Plugin.GroundTargetTypes) : Plugin.TargetTypes)
                                     if (ImGui.Selectable(target.TargetName))
                                         stackEntry.Target = target;
                             }
@@ -228,16 +233,23 @@ public partial class ConfigWindow
 
                         ImGui.SameLine();
                         ImGui.SetNextItemWidth(200);
-                        var selected = stackEntry.Action.RowId;
-                        if (ExcelSheetSelector<Lumina.Excel.Sheets.Action>.ExcelSheetCombo("Ability", ref selected, entry.Job, actionOptions))
+                        var selected = stackEntry.Action.RowId();
+                        using (var combo = ImRaii.Combo("Ability", stackEntry.Action.Name()))
                         {
-                            var ability = Sheets.ActionSheet.GetRow(selected);
+                            if (combo.Success)
+                            {
+                                foreach (var action in actionOptions)
+                                {
+                                    if (!ImGui.Selectable(action.Name()))
+                                        continue;
 
-                            stackEntry.Action = ability;
-                            if (ability.TargetArea && Plugin.GroundTargetTypes == stackEntry.Target)
-                                stackEntry.Target = null;
+                                    stackEntry.Action = action;
+                                    if (action.TargetArea() && Plugin.GroundTargetTypes == stackEntry.Target)
+                                        stackEntry.Target = null;
+                                }
+
+                            }
                         }
-
                         // Only show delete and reorder buttons if more than 1 entry
                         if (entry.Entries.Count <= 1)
                             continue;


### PR DESCRIPTION
Added functionality to set up an actions stack with Duty Action I and Duty Action 2
![afbeelding](https://github.com/user-attachments/assets/bac4591e-16b0-4f0e-a396-cc101a45c839)

technically speaking from behind the scenes it was quite a bit of effort for them to play nice as the GeneralActions are on another sheet than the normal actions.

functionally the flow is as follows:

1.  end-user sets up a stack with a duty action 1/2 as base action (general action 26/27)
2.  end-user presses duty action, this gets intercepted as "enduser casts spell 123123132123"
3.  we check if spell 123123123123 is equal to the spell current in duty action
4.  we apply stack tied to duty action (general action 26/27)
5.  if a stack comes through the pipeline asking to execute general action 26 or 27, we fetch the current spell of duty action 1/2 and ask the game if we can cast that spell at the target in the action stack


Edit: there was no easily usable DutyActionManager to fetch whatever is in the phantom actions (yet), so while they currently show up in the list of actions for an action stack, they currently do not do anything.
![afbeelding](https://github.com/user-attachments/assets/df3221f0-623c-4271-97e3-10496ac87871)

to remove them from the list you'd remove them here:     
```
//26/27 are duty actions, 31-35 are phantom skills, phantom skills not yet implemented
    public static readonly uint[] dutyActionRowIds = [26, 27, 31, 32, 33, 34, 35];
```
