### PR TITLE
[Feature] IPC

### DIFF
--- a/MOAction/IPCProvider.cs
+++ b/MOAction/IPCProvider.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+
+namespace MOAction;
+
+public static class IPCProvider
+{
+    private static Plugin? Plugin;
+    private static ICallGateProvider<uint[]> method_RetargetedActions = null!;
+
+    public static void RegisterIPC(Plugin plugin, IDalamudPluginInterface pluginInterface)
+    {
+        Plugin = plugin;
+
+        method_RetargetedActions = pluginInterface.GetIpcProvider<uint[]>("MOAction.RetargetedActions");
+        method_RetargetedActions.RegisterFunc(GetRetargetedActions);
+    }
+
+    private static uint[] GetRetargetedActions()
+    {
+        if (Plugin == null) return [];
+
+        List<uint> retargetedActions = [];
+        Plugin.MoAction.Stacks.ForEach(stack =>
+        {
+            // Add the base action
+            var baseAction = stack.BaseAction.RowId;
+            if (retargetedActions.Contains(baseAction)) return;
+            retargetedActions.Add(baseAction);
+
+            stack.Entries.ForEach(entry =>
+            {
+                // Add the action from the stack entry
+                var actionId = entry.Action.RowId;
+                if (actionId == baseAction || retargetedActions.Contains(actionId)) return;
+                retargetedActions.Add(actionId);
+            });
+        });
+
+        return retargetedActions.ToArray();
+    }
+
+    public static void Dispose()
+    {
+        method_RetargetedActions.UnregisterFunc();
+        Plugin = null;
+    }
+}

--- a/MOAction/Plugin.cs
+++ b/MOAction/Plugin.cs
@@ -69,6 +69,8 @@ public class Plugin : IDalamudPlugin
             ShowInHelp = true
         });
 
+        IPCProvider.RegisterIPC(this, PluginInterface);
+
         JobAbbreviations = Sheets.ClassJobSheet.Where(x => x.JobIndex > 0).OrderBy(c => c.Abbreviation.ExtractText()).ToList();
         ApplicableActions = Sheets.ActionSheet.Where(row => row is { IsPlayerAction: true, IsPvP: false, ClassJobLevel: > 0 }).Where(a => a.RowId != 212).ToList();
 
@@ -245,6 +247,7 @@ public class Plugin : IDalamudPlugin
         PluginInterface.UiBuilder.OpenConfigUi -= OpenUi;
         PluginInterface.UiBuilder.Draw -= Draw;
 
+        IPCProvider.Dispose();
         MoAction.Dispose();
         CommandManager.RemoveHandler("/pmoaction");
         CommandManager.RemoveHandler("/moaction");


### PR DESCRIPTION
This PR adds a very basic IPC with just one method:
- `uint[] RetargetedActions`
  - Iterates the Stack, adding each base action to a list
  - Iterates each Stack's Entries, adding each action (if new) to the same list

The IPC is initialized and disposed of properly in `Plugin.cs`.

The purpose of this method is to expose all actions that are being re-targeted in some manner by MOAction in a simple manner that could be used to detect conflicts in other plugins that do re-targeting of actions.

Closes #120 